### PR TITLE
Thread-local arenas

### DIFF
--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -3931,8 +3931,10 @@ _get_stats(PyObject *self, PyObject *args) {
         return NULL;
     }
 
-    MUTEX_LOCK(&ImagingDefaultArena.mutex);
-    ImagingMemoryArena arena = &ImagingDefaultArena;
+    ImagingMemoryArena arena = ImagingDefaultArena();
+    if (!arena) {
+        return NULL;
+    }
 
     v = PyLong_FromLong(arena->stats_new_count);
     PyDict_SetItemString(d, "new_count", v ? v : Py_None);
@@ -3958,7 +3960,6 @@ _get_stats(PyObject *self, PyObject *args) {
     PyDict_SetItemString(d, "blocks_cached", v ? v : Py_None);
     Py_XDECREF(v);
 
-    MUTEX_UNLOCK(&ImagingDefaultArena.mutex);
     return d;
 }
 
@@ -3968,14 +3969,16 @@ _reset_stats(PyObject *self, PyObject *args) {
         return NULL;
     }
 
-    MUTEX_LOCK(&ImagingDefaultArena.mutex);
-    ImagingMemoryArena arena = &ImagingDefaultArena;
+    ImagingMemoryArena arena = ImagingDefaultArena();
+    if (!arena) {
+        return NULL;
+    }
+
     arena->stats_new_count = 0;
     arena->stats_allocated_blocks = 0;
     arena->stats_reused_blocks = 0;
     arena->stats_reallocated_blocks = 0;
     arena->stats_freed_blocks = 0;
-    MUTEX_UNLOCK(&ImagingDefaultArena.mutex);
 
     Py_INCREF(Py_None);
     return Py_None;
@@ -3987,10 +3990,12 @@ _get_alignment(PyObject *self, PyObject *args) {
         return NULL;
     }
 
-    MUTEX_LOCK(&ImagingDefaultArena.mutex);
-    int alignment = ImagingDefaultArena.alignment;
-    MUTEX_UNLOCK(&ImagingDefaultArena.mutex);
-    return PyLong_FromLong(alignment);
+    ImagingMemoryArena arena = ImagingDefaultArena();
+    if (!arena) {
+        return NULL;
+    }
+
+    return PyLong_FromLong(arena->alignment);
 }
 
 static PyObject *
@@ -3999,10 +4004,12 @@ _get_block_size(PyObject *self, PyObject *args) {
         return NULL;
     }
 
-    MUTEX_LOCK(&ImagingDefaultArena.mutex);
-    int block_size = ImagingDefaultArena.block_size;
-    MUTEX_UNLOCK(&ImagingDefaultArena.mutex);
-    return PyLong_FromLong(block_size);
+    ImagingMemoryArena arena = ImagingDefaultArena();
+    if (!arena) {
+        return NULL;
+    }
+
+    return PyLong_FromLong(arena->block_size);
 }
 
 static PyObject *
@@ -4011,10 +4018,12 @@ _get_blocks_max(PyObject *self, PyObject *args) {
         return NULL;
     }
 
-    MUTEX_LOCK(&ImagingDefaultArena.mutex);
-    int blocks_max = ImagingDefaultArena.blocks_max;
-    MUTEX_UNLOCK(&ImagingDefaultArena.mutex);
-    return PyLong_FromLong(blocks_max);
+    ImagingMemoryArena arena = ImagingDefaultArena();
+    if (!arena) {
+        return NULL;
+    }
+
+    return PyLong_FromLong(arena->blocks_max);
 }
 
 static PyObject *
@@ -4034,9 +4043,12 @@ _set_alignment(PyObject *self, PyObject *args) {
         return NULL;
     }
 
-    MUTEX_LOCK(&ImagingDefaultArena.mutex);
-    ImagingDefaultArena.alignment = alignment;
-    MUTEX_UNLOCK(&ImagingDefaultArena.mutex);
+    ImagingMemoryArena arena = ImagingDefaultArena();
+    if (!arena) {
+        return NULL;
+    }
+
+    arena->alignment = alignment;
 
     Py_INCREF(Py_None);
     return Py_None;
@@ -4059,9 +4071,12 @@ _set_block_size(PyObject *self, PyObject *args) {
         return NULL;
     }
 
-    MUTEX_LOCK(&ImagingDefaultArena.mutex);
-    ImagingDefaultArena.block_size = block_size;
-    MUTEX_UNLOCK(&ImagingDefaultArena.mutex);
+    ImagingMemoryArena arena = ImagingDefaultArena();
+    if (!arena) {
+        return NULL;
+    }
+
+    arena->block_size = block_size;
 
     Py_INCREF(Py_None);
     return Py_None;
@@ -4079,15 +4094,18 @@ _set_blocks_max(PyObject *self, PyObject *args) {
         return NULL;
     }
 
+    ImagingMemoryArena arena = ImagingDefaultArena();
+    if (!arena) {
+        return NULL;
+    }
+
     if ((unsigned long)blocks_max >
-        SIZE_MAX / sizeof(ImagingDefaultArena.blocks_pool[0])) {
+        SIZE_MAX / sizeof(arena->blocks_pool[0])) {
         PyErr_SetString(PyExc_ValueError, "blocks_max is too large");
         return NULL;
     }
 
-    MUTEX_LOCK(&ImagingDefaultArena.mutex);
-    int status = ImagingMemorySetBlocksMax(&ImagingDefaultArena, blocks_max);
-    MUTEX_UNLOCK(&ImagingDefaultArena.mutex);
+    int status = ImagingMemorySetBlocksMax(arena, blocks_max);
     if (!status) {
         return ImagingError_MemoryError();
     }
@@ -4104,9 +4122,12 @@ _clear_cache(PyObject *self, PyObject *args) {
         return NULL;
     }
 
-    MUTEX_LOCK(&ImagingDefaultArena.mutex);
-    ImagingMemoryClearCache(&ImagingDefaultArena, i);
-    MUTEX_UNLOCK(&ImagingDefaultArena.mutex);
+    ImagingMemoryArena arena = ImagingDefaultArena();
+    if (!arena) {
+        return NULL;
+    }
+
+    ImagingMemoryClearCache(arena, i);
 
     Py_INCREF(Py_None);
     return Py_None;
@@ -4326,6 +4347,10 @@ setup_module(PyObject *m) {
         return -1;
     }
     if (PyType_Ready(&PixelAccess_Type) < 0) {
+        return -1;
+    }
+
+    if (ImagingMemoryArenaInit() != 0) {
         return -1;
     }
 

--- a/src/libImaging/Imaging.h
+++ b/src/libImaging/Imaging.h
@@ -161,15 +161,15 @@ typedef struct ImagingMemoryArena {
     int stats_reallocated_blocks; /* Number of blocks which were actually reallocated
                                      after retrieving */
     int stats_freed_blocks;       /* Number of freed blocks */
-#ifdef Py_GIL_DISABLED
-    PyMutex mutex;
-#endif
 } *ImagingMemoryArena;
 
 /* Objects */
 /* ------- */
 
-extern struct ImagingMemoryArena ImagingDefaultArena;
+extern int
+ImagingMemoryArenaInit(void);
+extern ImagingMemoryArena
+ImagingDefaultArena(void);
 extern int
 ImagingMemorySetBlocksMax(ImagingMemoryArena arena, int blocks_max);
 extern void

--- a/src/libImaging/Storage.c
+++ b/src/libImaging/Storage.c
@@ -218,9 +218,12 @@ ImagingNewPrologueSubtype(const char *mode, int xsize, int ysize, int size) {
             break;
     }
 
-    MUTEX_LOCK(&ImagingDefaultArena.mutex);
-    ImagingDefaultArena.stats_new_count += 1;
-    MUTEX_UNLOCK(&ImagingDefaultArena.mutex);
+    ImagingMemoryArena arena = ImagingDefaultArena();
+    if (!arena) {
+        return NULL;
+    }
+
+    arena->stats_new_count += 1;
 
     return im;
 }
@@ -257,23 +260,56 @@ ImagingDelete(Imaging im) {
 /* ------------------ */
 /* Allocate image as an array of line buffers. */
 
-#define IMAGING_PAGE_SIZE (4096)
+#include "Threading.h"
 
-struct ImagingMemoryArena ImagingDefaultArena = {
-    1,                 // alignment
-    16 * 1024 * 1024,  // block_size
-    0,                 // blocks_max
-    0,                 // blocks_cached
-    NULL,              // blocks_pool
-    0,
-    0,
-    0,
-    0,
-    0,  // Stats
-#ifdef Py_GIL_DISABLED
-    {0},
-#endif
-};
+static threading_key_t ImagingMemoryArenaKey;
+
+ImagingMemoryArena
+ImagingDefaultArena(void) {
+    ImagingMemoryArena arena = threading_get(ImagingMemoryArenaKey);
+
+    if (arena == NULL) {
+        arena = malloc(sizeof(*arena));
+        if (!arena) {
+            (void) ImagingError_MemoryError();
+            return NULL;
+        }
+
+        *arena = (struct ImagingMemoryArena){
+            1,                 // alignment
+            16 * 1024 * 1024,  // block_size
+            0,                 // blocks_max
+            0,                 // blocks_cached
+            NULL,              // blocks_pool
+            0,
+            0,
+            0,
+            0,
+            0,  // Stats
+        };
+
+        if (threading_set(ImagingMemoryArenaKey, arena) != 0) {
+            (void) ImagingError_MemoryError();
+            free(arena);
+            return NULL;
+        }
+    }
+
+    return arena;
+}
+
+static void
+ImagingDefaultArenaCleanup(void *arena) {
+    free(((ImagingMemoryArena)arena)->blocks_pool);
+    free(arena);
+}
+
+int
+ImagingMemoryArenaInit(void) {
+    return threading_init(&ImagingMemoryArenaKey, ImagingDefaultArenaCleanup);
+}
+
+#define IMAGING_PAGE_SIZE (4096)
 
 int
 ImagingMemorySetBlocksMax(ImagingMemoryArena arena, int blocks_max) {
@@ -369,12 +405,17 @@ ImagingDestroyArray(Imaging im) {
     int y = 0;
 
     if (im->blocks) {
-        MUTEX_LOCK(&ImagingDefaultArena.mutex);
+        ImagingMemoryArena arena = ImagingDefaultArena();
+
+        /* Asserting here instead of raising an error because expect that if we
+         * have entered this function that the arena has already been allocated.
+         */
+        assert(arena);
+
         while (im->blocks[y].ptr) {
-            memory_return_block(&ImagingDefaultArena, im->blocks[y]);
+            memory_return_block(arena, im->blocks[y]);
             y += 1;
         }
-        MUTEX_UNLOCK(&ImagingDefaultArena.mutex);
         free(im->blocks);
     }
 }
@@ -504,11 +545,14 @@ ImagingNewInternal(const char *mode, int xsize, int ysize, int dirty) {
         return NULL;
     }
 
-    MUTEX_LOCK(&ImagingDefaultArena.mutex);
+    ImagingMemoryArena arena = ImagingDefaultArena();
+    if (!arena) {
+        return NULL;
+    }
+
     Imaging tmp = ImagingAllocateArray(
-        im, &ImagingDefaultArena, dirty, ImagingDefaultArena.block_size
+        im, arena, dirty, arena->block_size
     );
-    MUTEX_UNLOCK(&ImagingDefaultArena.mutex);
     if (tmp) {
         return im;
     }
@@ -516,9 +560,7 @@ ImagingNewInternal(const char *mode, int xsize, int ysize, int dirty) {
     ImagingError_Clear();
 
     // Try to allocate the image once more with smallest possible block size
-    MUTEX_LOCK(&ImagingDefaultArena.mutex);
-    tmp = ImagingAllocateArray(im, &ImagingDefaultArena, dirty, IMAGING_PAGE_SIZE);
-    MUTEX_UNLOCK(&ImagingDefaultArena.mutex);
+    tmp = ImagingAllocateArray(im, arena, dirty, IMAGING_PAGE_SIZE);
     if (tmp) {
         return im;
     }

--- a/src/libImaging/Threading.h
+++ b/src/libImaging/Threading.h
@@ -1,0 +1,116 @@
+typedef void (threading_destructor_t)(void *);
+
+#ifdef _WIN32
+#include <process.h>
+#include <windows.h>
+
+/* A key that can be used to retrieve the thread-local value. */
+typedef DWORD threading_key_t;
+
+static int
+threading_ensure_fiber() {
+    if (!GetCurrentFiber()) {
+        if (!ConvertThreadToFiber(NULL)) {
+            return GetLastError();
+        }
+    }
+    return 0;
+}
+
+static void
+threading_destructor_noop(void *value) {
+    (void) value;
+}
+
+/* Initialize the threading key, with the given destructor callback. */
+static int
+threading_init(threading_key_t *key, threading_destructor_t *destructor) {
+    if (!key) {
+        return ERROR_INVALID_PARAMETER;
+    }
+
+    int error = wvls_ensure_fiber();
+    if (error) {
+        return error;
+    }
+
+    if (!destructor) {
+        destructor = wvls_destructor_noop;
+    }
+
+    *key = FlsAlloc((PFLS_CALLBACK_FUNCTION) destructor);
+    if (*key == FLS_OUT_OF_INDEXES) {
+        return GetLastError();
+    }
+
+    return 0;
+}
+
+/* Retrieve the thread-local value for the given threading key. */
+static void *
+threading_get(threading_key_t key) {
+    return (key && !threading_ensure_fiber()) ? FlsGetValue(key) : NULL;
+}
+
+/* Set the thread-local value for the given threading key. */
+static int
+threading_set(threading_key_t key, void *value) {
+    if (!key) {
+        return ERROR_INVALID_PARAMETER;
+    }
+
+    int error = threading_ensure_fiber();
+    if (error) {
+        return error;
+    }
+
+    /* If FlsGetValue returns NULL, it may be because the thread existed before
+     * the DLL was loaded (e.g., main thread or threads created by other
+     * libraries). In this case, we need to allocate memory for the TLS value
+     * and set it.
+     */
+    LPVOID lpvData = FlsGetValue(key);
+
+    if (!lpvData && GetLastError() != ERROR_SUCCESS) {
+        lpvData = LocalAlloc(LPTR, 256);
+
+        if (lpvData == NULL) {
+            return ERROR_NOT_ENOUGH_MEMORY;
+        }
+
+        if (!FlsSetValue(key, lpvData)) {
+            LocalFree(lpvData);
+            return GetLastError();
+        }
+    }
+
+    if (!FlsSetValue(key, value)) {
+        return GetLastError();
+    }
+
+    return 0;
+}
+#else
+#include <pthread.h>
+
+/* A key that can be used to retrieve the thread-local value. */
+typedef pthread_key_t threading_key_t;
+
+/* Initialize the threading key, with the given destructor callback. */
+static int
+threading_init(threading_key_t *key, threading_destructor_t *destructor) {
+    return pthread_key_create(key, destructor);
+}
+
+/* Retrieve the thread-local value for the given threading key. */
+static void *
+threading_get(threading_key_t key) {
+    return pthread_getspecific(key);
+}
+
+/* Set the thread-local value for the given threading key. */
+static int
+threading_set(threading_key_t key, void *value) {
+    return pthread_setspecific(key, value);
+}
+#endif


### PR DESCRIPTION
Currently, all threads use the same arena for imaging. This can result in a lot of contention when there are enough workers and the mutex is constantly being checked.

This commit instead introduces lockless thread-local arenas that are allocated on first use. The benchmark script is below:

<details>
<summary>Script</summary>

```python
import concurrent.futures
import os
import threading
import time

from PIL import Image

num_threads = 16
num_images = 1024


def operation():
    images = []
    for i in range(num_images):
        img = Image.new(
            "RGB", (100, 100), color=(i % 256, (i // 256) % 256, (i // 65536) % 256)
        )
        images.append(img)

    for img in images:
        img = img.convert("CMYK")

    images.clear()


def worker(barrier):
    barrier.wait()
    runtimes = []

    for _ in range(5):
        start_time = time.time()
        operation()
        end_time = time.time()
        runtimes.append(end_time - start_time)

    return runtimes


def benchmark():
    with concurrent.futures.ThreadPoolExecutor(max_workers=num_threads) as executor:
        barrier = threading.Barrier(num_threads)
        futures = [executor.submit(worker, barrier) for _ in range(num_threads)]

        run_times = []
        for future in concurrent.futures.as_completed(futures):
            try:
                run_times.extend(future.result())
            except IndexError:
                os._exit(-1)

        min_time = min(run_times)
        max_time = max(run_times)
        mean_time = sum(run_times) / len(run_times)
        print(f"Max: {max_time:.6f} Mean: {mean_time:.6f} Min: {min_time:.6f}")


benchmark()
```

</details>

Results on 3.10.9 are modest (about a 5% improvement):

```
== main
$ python3 test.py
Max: 0.418454 Mean: 0.367965 Min: 0.304827
$ python3 test.py
Max: 0.399601 Mean: 0.350857 Min: 0.296772
$ python3 test.py
Max: 0.383850 Mean: 0.340621 Min: 0.298339
$ python3 test.py
Max: 0.411377 Mean: 0.353988 Min: 0.301641
$ python3 test.py
Max: 0.458254 Mean: 0.366235 Min: 0.288733

== branch

$ python3 test.py
Max: 0.405619 Mean: 0.344232 Min: 0.292727
$ python3 test.py
Max: 0.371633 Mean: 0.330349 Min: 0.293776
$ python3 test.py
Max: 0.384050 Mean: 0.341127 Min: 0.290964
$ python3 test.py
Max: 0.405097 Mean: 0.344947 Min: 0.287725
$ python3 test.py
Max: 0.408996 Mean: 0.343053 Min: 0.281831
```

However results on 3.13.0 with the GIL disabled are much more significant (about a 70% improvement):

```
== main
$ python3 test.py             
Max: 0.182146 Mean: 0.130943 Min: 0.091334
$ python3 test.py
Max: 0.186941 Mean: 0.128363 Min: 0.086766
$ python3 test.py
Max: 0.195414 Mean: 0.132705 Min: 0.072013
$ python3 test.py
Max: 0.165168 Mean: 0.109613 Min: 0.075821
$ python3 test.py
Max: 0.175763 Mean: 0.115425 Min: 0.078984

== branch

$ python3 test.py
Max: 0.111725 Mean: 0.042197 Min: 0.018727
$ python3 test.py
Max: 0.141919 Mean: 0.044987 Min: 0.017759
$ python3 test.py
Max: 0.101010 Mean: 0.041082 Min: 0.017500
$ python3 test.py
Max: 0.102207 Mean: 0.038774 Min: 0.016476
$ python3 test.py
Max: 0.101062 Mean: 0.042766 Min: 0.016527
```