### PR TITLE
Only import distutils when type checking

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,6 @@
 # ------------------------------
 from __future__ import annotations
 
-import distutils.ccompiler
 import os
 import re
 import shutil
@@ -18,11 +17,14 @@ import sys
 import tempfile
 import warnings
 from collections.abc import Iterator
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext
 from setuptools.errors import CompileError
+
+if TYPE_CHECKING:
+    import distutils.ccompiler
 
 
 def get_version() -> str:


### PR DESCRIPTION
Suggestion for https://github.com/python-pillow/Pillow/pull/8714

https://github.com/python-pillow/Pillow/issues/4796 sought to move Pillow away from distutils. If the PR is going to reintroduce it, I suggest we only import it when type checking.